### PR TITLE
Add Image Captions

### DIFF
--- a/themes/hugo-refresh/layouts/_default/_markup/render-image.html
+++ b/themes/hugo-refresh/layouts/_default/_markup/render-image.html
@@ -1,0 +1,4 @@
+<figure>
+    <img src="{{ .Destination | safeURL }}" alt="{{ .Text }}">
+    <figcaption>{{ .Title }}</figcaption>
+  </figure>

--- a/themes/hugo-refresh/layouts/_default/_markup/render-image.html
+++ b/themes/hugo-refresh/layouts/_default/_markup/render-image.html
@@ -1,4 +1,4 @@
 <figure>
     <img src="{{ .Destination | safeURL }}" alt="{{ .Text }}">
     <figcaption>{{ .Title }}</figcaption>
-  </figure>
+</figure>


### PR DESCRIPTION
This PR adds the ability to display image captions below the image in the Blog articles if they exist by using the image title attribute.
Please see screenshot below for an example:
![Screenshot 2024-03-26 at 11 46 52](https://github.com/trento-project/trento-project.github.io/assets/40714533/39bc9353-89cf-4556-997e-cb5e5a9faba0)
