### PR TITLE
Add Author and Date to the Blog

### DIFF
--- a/content/blog/2024/release-2.3.1/index.md
+++ b/content/blog/2024/release-2.3.1/index.md
@@ -1,10 +1,11 @@
 ---
 title: "Announcing Trento Version 2.3.1"
 date: 2024-06-18T12:15:00+02:00
-hideLastModified: true
+hideLastModified: false
 showInMenu: false
 summary: "Trento 2.3 boasts an alternative, more traditional, installation process for Trento Server..."
 summaryImage: "trento-2-3-0-thumbnail@2x.png"
+author: "Alberto Bravo"
 ---
 
 Trento 2.3 boasts an alternative, more traditional, installation process for Trento Server based on rpm packages, enhanced discovery capabilities and a simpler, safer architecture thanks to the removal of Grafana and the introduction of a rotating API key. Let's review these new features more in detail.

--- a/themes/hugo-refresh/layouts/partials/blog/content.html
+++ b/themes/hugo-refresh/layouts/partials/blog/content.html
@@ -5,6 +5,13 @@
         <h1 class="title is-2 section-title">{{- .Title -}}</h1>
         <h5 class="subtitle is-5 is-muted">{{- .Params.Subtitle -}}</h5>
         <div class="divider"></div>
+        {{- if not .Params.hideLastModified -}}
+        <div class="blog-meta mt-20">
+          <p class="author is-inline">Written by&nbsp;{{- .Params.Author -}}</p>
+          <p class="seperator is-inline px-10">|</p>
+          <p class="date is-inline">Published&nbsp;{{- .Date.Format "2 January 2006" -}}</p>
+        </div>
+        {{- end -}}
         <section class="section content has-text-justified">
             {{- .Content -}}
         </section>

--- a/themes/hugo-refresh/layouts/partials/blog/content.html
+++ b/themes/hugo-refresh/layouts/partials/blog/content.html
@@ -18,14 +18,4 @@
       </div>
     </div>
   </div>
-  {{- if not .Params.hideLastModified -}}
-  <div class="container">
-    <div class="columns">
-      <div class="column has-text-right is-family-monospace is-centered-tablet-portrait">
-        {{ i18n "lastModified" }}:&nbsp;
-        {{- .Lastmod.Format "2 January 2006" -}}
-      </div>
-    </div>
-  </div>
-  {{- end -}}
 </section>


### PR DESCRIPTION
This PR adds the **author** and **date** information below each blog title.
Old articles will have to be updated with the author name and the `hideLastModified` variable will have to be set as false.
FYI the old way of displaying the date at the bottom of the article has been removed as it would be a duplication of information.

Screenshot attached below for reference.
<img width="1500" alt="Screenshot 2024-06-26 at 10 52 44" src="https://github.com/trento-project/trento-project.github.io/assets/40714533/71740f6f-e61b-40f6-98d4-f41e49a0ca8d">
