### PR TITLE
add a docs page with a collection of links

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -47,4 +47,4 @@ The Trento Agents are shipped with SUSE Linux Enterprise Server for SAP Applicat
 ## Get Started with Trento
 Use Trento with you SAP Application server and improve the overall visibility and discovery of faults which are aligned to the SUSE SAP Best Practice Guidelines.
 
-{{< button class="is-primary" link="https://github.com/trento-project/docs" alt="Start Reading the Trento Documentation" >}}Read Documentation{{< /button >}}
+{{< button class="is-primary" link="/docs" alt="Start Reading the Trento Documentation" >}}Read Documentation{{< /button >}}

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -27,5 +27,8 @@ This is distilled from various upstream components, each with their own document
 ### Trento Helm charts
 - [README.md](https://github.com/trento-project/helm-charts/blob/main/README.md)
 
+### Trento Ansible playbook
+- [README.md](https://github.com/trento-project/ansible/blob/main/README.md)
+
 ### Miscellaneous
 Further notes of various nature are available at [github.com/trento-project/docs](https://github.com/trento-project/docs).

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -1,0 +1,31 @@
+---
+title: "Documentation"
+hideLastModified: true
+showInMenu: true
+---
+
+## Official SUSE documentation
+
+The official documentation is hosted at **[documentation.suse.com/sles-sap/trento](https://documentation.suse.com/sles-sap/trento/)**.
+
+This is distilled from various upstream components, each with their own documentation.
+
+## Upstream documentation
+
+### Trento Web
+
+- [Repository documentation](https://www.trento-project.io/web/)
+- [OpenAPI specification](https://www.trento-project.io/web/swaggerui/)
+
+### Trento Wanda
+- [Repository documentation](https://www.trento-project.io/wanda/)
+- [OpenAPI specification](https://www.trento-project.io/wanda/swaggerui/)
+
+### Trento Agent
+- [README.md](https://github.com/trento-project/agent/blob/main/README.md)
+
+### Trento Helm charts
+- [README.md](https://github.com/trento-project/helm-charts/blob/main/README.md)
+
+### Miscellaneous
+Further notes of various nature are available at [github.com/trento-project/docs](https://github.com/trento-project/docs).


### PR DESCRIPTION
I don't like it that much but better than nothing.
![Screenshot 2024-06-27 143428](https://github.com/trento-project/trento-project.github.io/assets/2952427/3e6ba506-5704-4818-8c25-5388d2c95330)
