### PR TITLE
Adds Author and Date for Blog Summary View

### DIFF
--- a/content/blog/2024/new-logo-2024/index.md
+++ b/content/blog/2024/new-logo-2024/index.md
@@ -1,10 +1,11 @@
 ---
 title: "The Story of Trento's Logo Redesign"
 date: 2024-03-22T12:00:00+02:00
-hideLastModified: true
+hideLastModified: false
 showInMenu: false
 summary: "It has been just over 3 years (2 Feb 2021) since the humble beginnings of the Trento project."
 summaryImage: "trento-logo-2024-thumbnail@2x.png"
+author: "Jurgen Goldschmidt" 
 ---
 ![Trento Logo 2024 Landscape](new-trento-logo-landscape@2x.png)
 

--- a/content/blog/release-2.0.0/index.md
+++ b/content/blog/release-2.0.0/index.md
@@ -1,10 +1,11 @@
 ---
 title: "Announcing Trento Version 2.0.0"
 date: 2023-05-04T16:21:00+02:00
-hideLastModified: true
+hideLastModified: false
 showInMenu: false
 summary: "Available beginning of May’23, Trento 2.0.0 brings major changes to the architecture of the solution..."
 summaryImage: "trento-2-0-0-thumbnail@2x.png"
+author: "Alberto Bravo"
 ---
 ![Trento Release Version 2.0.0](trento-release-2-0-0-hero@2x.png)
 

--- a/content/blog/release-2.1.0/index.md
+++ b/content/blog/release-2.1.0/index.md
@@ -1,10 +1,11 @@
 ---
 title: "Announcing Trento Version 2.1.0"
 date: 2023-08-16T08:20:00+02:00
-hideLastModified: true
+hideLastModified: false
 showInMenu: false
 summary: "Trento 2.0.0 was a turning point in the Project as it introduced a redesigned, more secure and faster..."
 summaryImage: "trento-2-1-0-thumbnail@2x.png"
+author: "Alberto Bravo"
 ---
 
 Trento 2.0.0 was a turning point in the Project as it introduced a redesigned, more secure and faster checks engine. Past this milestone, the Project refocuses on strengthening the application capabilities around configuration checks -to leverage the new checks engine-, monitoring -to improve observability- and, ultimately, automation. New versions with new user-facing features will be delivered at a faster pace and Trento 2.1.0 is just the first step in the road.

--- a/content/blog/release-2.2.0/index.md
+++ b/content/blog/release-2.2.0/index.md
@@ -1,10 +1,11 @@
 ---
 title: "Announcing Trento Version 2.2.0"
 date: 2023-12-04T12:15:00+02:00
-hideLastModified: true
+hideLastModified: false
 showInMenu: false
 summary: "Version 2.2.0 deepens the observability capabilities of Trento with the integration of saptune..."
 summaryImage: "trento-2-2-0-thumbnail@2x.png"
+author: "Alberto Bravo"
 ---
 
 Version 2.2.0 deepens the observability capabilities of Trento with the integration of saptune in the console and kicks off the process to expand the configuration checks catalog to other HA scenarios, such as ASCS/ERS clusters, and other targets in the environment, such as hosts.

--- a/themes/hugo-refresh/layouts/partials/single/summary.html
+++ b/themes/hugo-refresh/layouts/partials/single/summary.html
@@ -45,7 +45,7 @@
         </a>
       </figure>
       <h3 class="title is-5 refresh-summary-title">
-        {{ .Params.title }}
+        <a href="{{- .Permalink | relURL -}}">{{ .Params.title }}</a>
       </h3>
       <p class="refresh-summary">
         {{- if .Params.summary -}}
@@ -53,11 +53,13 @@
         {{- else }}
           {{- .Plain -}}
         {{- end -}}
-      </p> 
-      <div class="action has-text-right">
-        <a href="{{- .Permalink | relURL -}}" class="button is-primary">
-                {{ i18n "readMore" }}
-            </a>
-      </div>
+      </p>
+      <div class="has-text-left">
+        {{- if .Params.author -}}
+          {{ .Params.author }}
+        {{- end -}}
+        <br>
+        {{ .Date.Format "2 Jan 2006" }}
+      </div> 
     </div>
   </div>


### PR DESCRIPTION
Changes view of Blog Summary component to include author and date. This PR also removes the **Read More** button and adds the link to the article title of each post instead. This allows for a better display of elements when viewing the page on smaller devices.

Reference attached below:
<img width="1404" alt="Screenshot 2024-07-09 at 10 57 07" src="https://github.com/trento-project/trento-project.github.io/assets/40714533/1e5d744d-0b7f-4c9f-8527-059fbf935463">
