### PR TITLE
Fix link to docs page again

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -168,7 +168,7 @@ languages:
 menu:
  main:
    - name: "Documentation"
-     url: "https://www.trento-project.io/docs-site"
+     url: "https://www.trento-project.io/docs"
      weight: 100
      params:
        target: "_blank"


### PR DESCRIPTION
Just a follow up to https://github.com/trento-project/docs/pull/86 as we move docs site to docs