### PR TITLE
[TRNT-4330] Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
This PR adds the configuration for Dependabot, so that we can get automated updates when the dependencies change. This configuration also includes a cooldown period, to align with the configuration used in other repositories.

Related # TRNT-4330